### PR TITLE
Task 12: Preserve dist path in prod build

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,14 +11,18 @@ try {
 
   // Create build directory structure
   fs.mkdirSync(BUILD_DIR, { recursive: true })
-  fs.mkdirSync(path.join(BUILD_DIR, 'css'), { recursive: true })
+  fs.mkdirSync(path.join(BUILD_DIR, 'dist'), { recursive: true }) // Mirror dist/ so index.html keeps working on prod (see PLAN.md § Deployment pipeline)
   fs.mkdirSync(path.join(BUILD_DIR, 'src/images'), { recursive: true })
 
   // Copy files
   const filesToCopy = [
     { src: 'index.html', dest: 'index.html', required: true },
     { src: 'CNAME', dest: 'CNAME', required: false },
-    { src: 'dist/main.css', dest: 'css/main.css', required: true },
+    {
+      src: 'dist/main.css',
+      dest: 'dist/main.css',
+      required: true,
+    }, // Preserve dist/main.css path to avoid 404 from index.html link
     {
       src: 'src/images/favicon.ico',
       dest: 'src/images/favicon.ico',

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       content="senior full stack developer, react developer, nodejs developer, typescript, technical lead, azure, aws, ci/cd, playwright, test automation, ottawa developer, vaibhav mande"
     />
     <meta name="author" content="Vaibhav Mande" />
+    <!-- Keep referencing dist/main.css so dev server and production artifact share one path -->
     <link rel="stylesheet" href="dist/main.css" />
     <link
       rel="shortcut icon"


### PR DESCRIPTION
**Description**

- Keep index.html referencing dist/main.css so local dev and prod share one URL, with an inline note documenting the rationale @/index.html#17-33.
- Update build.js to mirror the dist/ directory inside build/ and copy dist/main.css into that same path, preventing 404s after deployment @/build.js#12-31.

Testing
1. npm run build
2. npm run build:prod