### PR TITLE
Fix: Center content layout by narrowing container width

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -79,11 +79,13 @@ ul {
 }
 
 // Shared container — max-width centered layout with responsive horizontal padding
+// Reduced from 860px to 700px — matches leerob.io's narrower single-column feel,
+// creates more equal left/right breathing room and makes content read as centered
 .container {
-  max-width: 860px;
+  max-width: 700px;
   width: 100%;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 32px;
 }
 
 // ─── Hero ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The hero content appeared left-aligned rather than centered because the container was too wide (860px), leaving minimal breathing room on the right side.